### PR TITLE
Deactivate ssh compression per default

### DIFF
--- a/.ssh/config
+++ b/.ssh/config
@@ -14,7 +14,7 @@ Host *
 	ControlPersist 1800
 
 	# also this stuff
-	Compression yes
+	Compression no
 	TCPKeepAlive yes
 	ServerAliveInterval 20
 	ServerAliveCountMax 10


### PR DESCRIPTION
Following the ssh manpage, compression should only be used on very slow or dial-up connections (on other connections compression would be slowing down the connection)